### PR TITLE
16 - leader board page

### DIFF
--- a/packages/client/src/pages/leaderBoard/leaderBoard.tsx
+++ b/packages/client/src/pages/leaderBoard/leaderBoard.tsx
@@ -1,20 +1,109 @@
 import { Page } from '@components/page';
 import { ROUTES } from '@constants/routes';
-import { Button } from '@mui/material';
-import React from 'react';
+import { Avatar, Button, Stack, Box } from '@mui/material';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+// will be replaced by api logic
+import { getMockData, type TLeaderBoardItem } from './mockData';
+import styles from './styles.module.scss';
+
+type TData = TLeaderBoardItem[];
+
+// mock for getting chunkSize elements per request
+const chunkSize = 5;
+// need authorization and api for this logic - just mock for now
+const currentPlayerRank = 6;
+
+const LeaderboardRow = ({
+    rank,
+    displayName,
+    points,
+    avatarSrc,
+}: TLeaderBoardItem & { rank: number }) => (
+    <Box
+        className={`
+            ${styles.row}
+            ${currentPlayerRank === rank ? styles.currentPlayer : ''}
+            ${rank <= 3 ? styles.greatRank : ''}
+        `}
+    >
+        <p className={styles.rank}>#{rank}</p>
+        <Avatar alt={displayName} src={avatarSrc} className={styles.avatar} />
+        <p className={styles.name}>{displayName}</p>
+        <p className={styles.points}>{points} pts</p>
+    </Box>
+);
 
 const LeaderBoardPage = () => {
     const navigate = useNavigate();
 
+    const [data, setData] = useState([] as TData);
+    const listRef = useRef<HTMLDivElement | null>(null);
+    const bottomRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        setData(getMockData(0, chunkSize));
+    }, []);
+
+    const loadMore = useCallback(() => {
+        setData((prev) => {
+            // may be hasmore logic will be implemented in api
+            // for now get the data and check if has elements
+            const nextPart = getMockData(prev.length, chunkSize);
+            if (nextPart.length === 0) {
+                return prev;
+            }
+
+            return [...prev, ...nextPart];
+        });
+    }, []);
+
+    useEffect(() => {
+        const container = listRef.current;
+        const bottomMarker = bottomRef.current;
+        if (!container || !bottomMarker) {
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const entry = entries[0];
+                if (entry.isIntersecting) {
+                    loadMore();
+                }
+            },
+            {
+                root: container,
+                threshold: 1,
+            }
+        );
+
+        observer.observe(bottomMarker);
+
+        return () => observer.disconnect();
+    }, [loadMore]);
+
     return (
-        <Page>
+        <Page className={styles.container}>
+            <h1>Таблица победителей</h1>
+            <h2>Твой ранк - #{currentPlayerRank}</h2>
+            <Stack spacing={1} className={styles.table} ref={listRef}>
+                {data.map((item) => (
+                    <LeaderboardRow key={item.rank} {...item} />
+                ))}
+                <div
+                    id="bottom"
+                    ref={bottomRef}
+                    className={styles.bottomMarker}
+                />
+            </Stack>
             <Button
                 variant="contained"
                 color="primary"
                 onClick={() => navigate(ROUTES.MENU)}
             >
-                Назад
+                Назад к меню
             </Button>
         </Page>
     );

--- a/packages/client/src/pages/leaderBoard/mockData.ts
+++ b/packages/client/src/pages/leaderBoard/mockData.ts
@@ -1,0 +1,90 @@
+export type TLeaderBoardItem = {
+    avatarSrc: string;
+    displayName: string;
+    points: number;
+    rank: number;
+};
+
+export const mockData: TLeaderBoardItem[] = [
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1546182990-dffeafbe841d?auto=format&fit=crop&w=200&q=80',
+        displayName: 'BubbleHunter',
+        points: 820,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1517849845537-4d257902454a?auto=format&fit=crop&w=200&q=80',
+        displayName: 'PopMaster',
+        points: 510,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1537151625747-768eb6cf92b6?auto=format&fit=crop&w=200&q=80',
+        displayName: 'ClickStorm',
+        points: 295,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1548199973-03cce0bbc87b?auto=format&fit=crop&w=200&q=80',
+        displayName: 'SpeedTap',
+        points: 970,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1526336024174-e58f5cdd8e13?auto=format&fit=crop&w=200&q=80',
+        displayName: 'VirusBuster',
+        points: 655,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1488426862026-3ee34a7d66df?auto=format&fit=crop&w=200&q=80',
+        displayName: 'BubbleMonk',
+        points: 610,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1529665253569-6d01c0eaf7b6?auto=format&fit=crop&w=200&q=80',
+        displayName: 'SwipeNova',
+        points: 575,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&w=200&q=80',
+        displayName: 'PixelPunk',
+        points: 540,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=200&q=80',
+        displayName: 'TapQueen',
+        points: 520,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=200&q=80',
+        displayName: 'BurstPilot',
+        points: 505,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1481277542470-605612bd2d61?auto=format&fit=crop&w=200&q=80',
+        displayName: 'ZapWizard',
+        points: 480,
+    },
+    {
+        avatarSrc:
+            'https://images.unsplash.com/photo-1520813792240-56fc4a3765a7?auto=format&fit=crop&w=200&q=80',
+        displayName: 'ClickBot',
+        points: 455,
+    },
+]
+    .sort((a, b) => b.points - a.points)
+    .map((item, index) => ({ ...item, rank: index + 1 }));
+
+export function getMockData(
+    lastIndex: number,
+    chunkSize: number
+): TLeaderBoardItem[] {
+    return mockData.slice(lastIndex, lastIndex + chunkSize);
+}

--- a/packages/client/src/pages/leaderBoard/styles.module.scss
+++ b/packages/client/src/pages/leaderBoard/styles.module.scss
@@ -1,0 +1,72 @@
+$currentPlayerColor: rgb(67, 183, 225);
+$winnerColor: rgb(253, 193, 14);
+
+.container {
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 2rem 1rem;
+    align-items: center;
+}
+
+.table {
+    width: 40rem;
+    max-height: 25rem;
+    overflow-y: auto;
+    padding-right: 1rem;
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.2rem 1rem;
+    border: 1px solid white;
+    border-radius: 1rem;
+
+    &.currentPlayer {
+        border: 1px solid $currentPlayerColor;
+        background-color: rgba($currentPlayerColor, 0.2);
+
+        .name {
+            color: $currentPlayerColor;
+            font-size: 1.2rem;
+            font-weight: 500;
+        }
+    }
+
+    &.greatRank {
+        background-color: rgba($winnerColor, 0.1);
+        border: 1px solid $winnerColor;
+
+        .rank {
+            font-size: 2rem;
+            color: $winnerColor;
+        }
+
+    }
+}
+
+.rank {
+    width: 3rem;
+    text-align: right;
+    font-weight: 700;
+}
+
+
+.name {
+    flex: 1;
+}
+
+.points {
+    width: 6rem;
+    text-align: right;
+    font-weight: 600;
+}
+
+.bottomMarker {
+    width: 100%;
+    height: 1px;
+}


### PR DESCRIPTION
### Какую задачу решаем
верстка страницы таблицы победителей
сейчас на моках, как сами данные таблицы так и ранк текущего игрока
есть подгрузка нового чанка при скроле до конца таблицы

### Скриншоты/видяшка (если есть)

на скринах желтый - лидеры, синий - текущий игрок

<img width="1582" height="969" alt="Screenshot 2025-11-14 at 19 20 28" src="https://github.com/user-attachments/assets/1bf38f0b-b3f0-4516-b1d7-cd8c5744be7a" />

<img width="1582" height="969" alt="Screenshot 2025-11-14 at 19 20 16" src="https://github.com/user-attachments/assets/0afad68e-2a3a-4277-af08-f07ffbc45b74" />

https://github.com/user-attachments/assets/351d81a0-7e79-445f-b1e5-6e96380718e2



### TBD (если есть)
прикрутить апи получения данных
обсудить с командой продуктовую логику - как лучше показывать текущего игрока если он на сотом месте
дизайн стоит обсудить и  причесать весь проект под одни цвета